### PR TITLE
Fix Mixin Related Server Crash

### DIFF
--- a/src/main/resources/efm_ex.mixins.json
+++ b/src/main/resources/efm_ex.mixins.json
@@ -5,10 +5,10 @@
   "compatibilityLevel": "JAVA_17",
   "refmap": "efm_ex.refmap.json",
   "mixins": [
-    "MixinGuard",
-    "MixinParryingSkill"
   ],
   "client": [
+    "MixinGuard",
+    "MixinParryingSkill"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixed my server.

Fixes a Server crash related to running Client Side Mixins on Server side. 

This crash has been present since mixins were introduced to the code in 20.9.4.7.

This fix is required in order to use BattleArts 20.9.6.0 on server.

Closes #1 